### PR TITLE
Check if client is not 'undefined' because it will be if project use …

### DIFF
--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -79,7 +79,7 @@ module.exports.wrap = model => {
     try {
       const client = await getClient()
 
-      if (client.batchSize) {
+      if (client && client.batchSize) {
         return await this.__proto__.find.apply(this, arguments).batchSize(client.batchSize)
       }
 


### PR DESCRIPTION
Check if client is not 'undefined' because it will be if project use getClient without createClient